### PR TITLE
version 1.0-11? 

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+v1.0-11 -- 26 Sep 2022
+  - explicit calls to contamMix S3 class functions to avoid errors in certain newer versions of R.
+  - more flexible multithreading, for compatibility with HPCs.
+
 v1.0-10 -- 16 Jan 2014
   - add trivial configure script to twiddle shebang in exec/estimate.R
 

--- a/exec/estimate.R
+++ b/exec/estimate.R
@@ -64,7 +64,7 @@ data = loadSAM(samFn=opt$samFn, malnFn=opt$malnFn, endogId=opt$consId, baseqThre
 res = runChains(nChains=opt$nChains, nIter=opt$nIter, data=data, alpha=opt$alpha)
 
 ## results in text format
-print(res, tabDelim=opt$tabOutput)
+print.contamMix(res, tabDelim=opt$tabOutput)
 
 ## binary save of results
 if (!is.null(opt$saveData)) {
@@ -81,7 +81,7 @@ if (!is.null(opt$figure)) {
   
   dev.new(file=opt$figure, width=4, height=6, pointsize=10)
   par(mfrow=c(3,1), cex=1, mex=0.5, mar=c(5,5,1,1), oma=c(0,0,3,0))
-  plot(res, which=1:3)
+  plot.contamMix(res, which=1:3)
   mtext(opt$samFn, side=3, line=1, outer=TRUE, font=2)
   mtext(bquote(paste("(", epsilon, " = ", .(signif(res$e,2)), ")")), side=3, line=-1, outer=TRUE)
   invisible(dev.off())


### PR DESCRIPTION
Changes: 
  - explicit calls to contamMix S3 class functions to avoid errors in certain newer versions of R.
  - more flexible multithreading, for compatibility with HPCs.

The old behaviour of contamMix to parallelise across all available cores does not scale very well for use in HPCs. By default contamMix now uses 1 core to run, unless more are requested.

I have tested the proposed changes on the HPC cluster in MPI EVA. Seems to work as intended.

`NEWS` has been updated to reflect the changes, but I have not touched any other part of the R package guts atm.